### PR TITLE
Change gdextension dependencies so they're actually used, patch the SDK

### DIFF
--- a/project/addons/discord-sdk-gd/discord-rpc-gd.gdextension
+++ b/project/addons/discord-sdk-gd/discord-rpc-gd.gdextension
@@ -17,13 +17,13 @@ linux.release.rv64 = "bin/linux/libdiscord_game_sdk_binding.so"
 
 [dependencies]
 
-macos.debug = "bin/macos/libdiscord_game_sdk.dylib"
-macos.release = "bin/macos/libdiscord_game_sdk.dylib"
-windows.debug.x86_64 = "bin/windows/discord_game_sdk.dll"
-windows.release.x86_64 = "bin/windows/discord_game_sdk.dll"
-linux.debug.x86_64 = "bin/linux/libdiscord_game_sdk.so"
-linux.release.x86_64 = "bin/linux/libdiscord_game_sdk.so"
-linux.debug.arm64 = "bin/linux/libdiscord_game_sdk.so"
-linux.release.arm64 = "bin/linux/libdiscord_game_sdk.so"
-linux.debug.rv64 = "bin/linux/libdiscord_game_sdk.so"
-linux.release.rv64 = "bin/linux/libdiscord_game_sdk.so"
+macos.debug = { "bin/macos/libdiscord_game_sdk.dylib": "" }
+macos.release = { "bin/macos/libdiscord_game_sdk.dylib": "" }
+windows.debug.x86_64 = { "bin/windows/discord_game_sdk.dll": "" }
+windows.release.x86_64 = { "bin/windows/discord_game_sdk.dll": "" }
+linux.debug.x86_64 = { "bin/linux/libdiscord_game_sdk.so": "" }
+linux.release.x86_64 = { "bin/linux/libdiscord_game_sdk.so": "" }
+linux.debug.arm64 = { "bin/linux/libdiscord_game_sdk.so": "" }
+linux.release.arm64 = { "bin/linux/libdiscord_game_sdk.so": "" }
+linux.debug.rv64 = { "bin/linux/libdiscord_game_sdk.so": "" }
+linux.release.rv64 = { "bin/linux/libdiscord_game_sdk.so": "" }

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,12 @@ import os
 with zipfile.ZipFile("src/lib/discord_game_sdk.zip", "r") as zip_ref:
     zip_ref.extractall("src/lib/discord_game_sdk/")
 
+# Patch the SDK to actually build, since it's missing an include
+with open("src/lib/discord_game_sdk/cpp/types.h", "r+") as f:
+    s = f.read();
+    f.seek(0);
+    f.write("#include <cstdint>\n" + s)
+
 copy_tree("src/lib/discord_game_sdk/lib/", "src/lib/discord_game_sdk/bin/")
 os.rename(
     "src/lib/discord_game_sdk/bin/aarch64/discord_game_sdk.dylib",


### PR DESCRIPTION
This part isn't very well documented, but they changed the format of that file at some point and now it needs to be like this to pull the dependencies into the built project. Assuming this is what the export plugin does, that can probably be removed.

Also, a file in the discord SDK is missing an include that is required to build it, so patch that in in setup.py