### PR TITLE
Better platform detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ src/lib/discord_game_sdk/
 
 # release.py
 release/
+
+# venv
+venv/

--- a/build.py
+++ b/build.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 yes = {"yes", "y", "ye", ""}
@@ -16,15 +17,16 @@ if choice in yes:
         "python -m SCons && python -m SCons target=template_release && cd project && godot"
     )
 elif choice in no:
-    if os.name == "nt":  # Windows
+    system = platform.system()
+    if system == "Windows": # Windows
         os.system(
-            "python -m SCons && python -m SCons target=template_release && godot project\project.godot"
+            "python -m SCons && python -m SCons target=template_release && godot project/project.godot"
         )
-    elif os.name == "darwin":  # macOS
+    elif system == "Darwin":  # macOS
         os.system(
             "python -m SCons target=template_release arch=x86_64 && python -m SCons target=template_debug arch=x86_64 && python -m SCons target=template_release arch=arm64 && python -m SCons target=template_debug arch=arm64 && godot project/project.godot"
         )
-    else:
+    else:  # Linux
         os.system(
             "python -m SCons && python -m SCons target=template_release && godot project/project.godot"
         )

--- a/build.py
+++ b/build.py
@@ -18,6 +18,7 @@ if choice in yes:
     )
 elif choice in no:
     system = platform.system()
+    print("Building for: '%s'" % (system))
     if system == "Windows": # Windows
         os.system(
             "python -m SCons && python -m SCons target=template_release && godot project/project.godot"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+scons


### PR DESCRIPTION
The os.name for a M2 mac (not sure about the intel versions) comes back as posix, not darwin.
So, to better facilitate multi-platform building, I've switched the build.py file to use **platform**.
I've also added a requirements.txt file for people (like myself) that use **venv** and **pip -r**