### PR TITLE
Make macos version work (testes on m1 at least)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,8 +4,8 @@ import os
 env = SConscript("src/lib/godot-cpp/SConstruct")
 
 if env["platform"] == "macos":
-    discord_library = "discord_game_sdk.dylib"
-    discord_library_second = "discord_game_sdk_aarch64.dylib"
+    discord_library = "libdiscord_game_sdk.dylib"
+    discord_library_second = ""
     libexportfolder = "/macos/"
 
 elif env["platform"] in ("linuxbsd", "linux"):

--- a/project/addons/discord-sdk-gd/bin/discord-rpc-gd.gdextension
+++ b/project/addons/discord-sdk-gd/bin/discord-rpc-gd.gdextension
@@ -5,10 +5,10 @@ compatibility_minimum = 4.2
 
 [libraries]
 
-macos.debug.x86_64 = "macos/discord_game_sdk_binding_debug.dylib"
-macos.release.x86_64 = "macos/discord_game_sdk_binding.dylib"
-macos.debug.arm64 = "macos/discord_game_sdk_binding_arm64_debug.dylib"
-macos.release.arm64 = "macos/discord_game_sdk_binding_arm64.dylib"
+macos.debug.x86_64 = "macos/libdiscord_game_sdk_binding_debug.dylib"
+macos.release.x86_64 = "macos/libdiscord_game_sdk_binding.dylib"
+macos.debug.arm64 = "macos/libdiscord_game_sdk_binding_arm64_debug.dylib"
+macos.release.arm64 = "macos/libdiscord_game_sdk_binding_arm64.dylib"
 windows.debug.x86_64 = "windows/discord_game_sdk_binding_debug.dll"
 windows.release.x86_64 = "windows/discord_game_sdk_binding.dll"
 linux.debug.x86_64 = "linux/libdiscord_game_sdk_binding_debug.so"
@@ -20,10 +20,7 @@ linux.release.rv64 = "linux/libdiscord_game_sdk_binding.so"
 
 [dependencies]
 
-macos.debug.x86_64 = { "macos/discord_game_sdk.dylib": "" }
-macos.release.x86_64 = { "macos/discord_game_sdk.dylib": "" }
-macos.debug.arm64 = { "macos/discord_game_sdk_aarch64": "" }
-macos.release.arm64 = { "macos/discord_game_sdk_aarch64": "" }
+macos = { "macos/libdiscord_game_sdk.dylib": "" }
 windows.debug.x86_64 = { "windows/discord_game_sdk.dll": "" }
 windows.release.x86_64 = { "windows/discord_game_sdk.dll": "" }
 linux.debug.x86_64 = { "linux/libdiscord_game_sdk.so": "" }

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import zipfile
 from distutils.dir_util import copy_tree
 import shutil
 import os
+import sys
 
 with zipfile.ZipFile("src/lib/discord_game_sdk.zip", "r") as zip_ref:
     zip_ref.extractall("src/lib/discord_game_sdk/")
@@ -42,5 +43,15 @@ shutil.rmtree("src/lib/discord_game_sdk/bin/aarch64/", ignore_errors=True)
 shutil.rmtree("src/lib/discord_game_sdk/bin/x86/", ignore_errors=True)
 shutil.rmtree("src/lib/discord_game_sdk/bin/x86_64/", ignore_errors=True)
 os.remove("src/lib/discord_game_sdk/README.md")
+
+if sys.platform == "darwin":
+    # Combine the two libraries into one
+    os.system("lipo src/lib/discord_game_sdk/bin/{discord_game_sdk.dylib,discord_game_sdk_aarch64.dylib} -output src/lib/discord_game_sdk/bin/libdiscord_game_sdk.dylib -create")
+    # Change the install name to (library's location)/(its new name)
+    os.system("install_name_tool -id '@loader_path/libdiscord_game_sdk.dylib'\
+    src/lib/discord_game_sdk/bin/libdiscord_game_sdk.dylib")
+    # Remove the ones it's made of
+    os.remove("src/lib/discord_game_sdk/bin/discord_game_sdk.dylib")
+    os.remove("src/lib/discord_game_sdk/bin/discord_game_sdk_aarch64.dylib")
 
 os.system("git submodule update --init --remote")


### PR DESCRIPTION
1. Change name of discord's library to libdiscord_game_sdk, so it links properly
2. Change its install name with install_name_tool to use @loader_path instead of @rpath, that one's on discord's side, it should really have been loader_path from the beginning (rpath means look at where the binary is started from, loader_path means look at where the library is)
3. Combine the aarch and x86 library into one, again no idea why discord does not do this themselves